### PR TITLE
Minor Readme Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,11 @@ Escaping
 
 You can set a key with a dot, or any other reserved character by escaping it:
 
-    from datapath.crud import get_path
-     
-    print get_path('a\\.b', {'a.b' : 5})  # 5!
+```python
+from datapath.crud import get_path
+ 
+print get_path('a\\.b', {'a.b' : 5})  # 5!
+```
 
 Compliance levels
 -----------------
@@ -82,20 +84,22 @@ moment:
 Enough talking!
 ---------------
 
-    from datapath.crud import get_path, find_path, set_path
+```python
+from datapath.crud import get_path, find_path, set_path
+
+data = {
+    'a': ['hello', 'world'],
+    'b': 5
+}
     
-    data = {
-        'a': ['hello', 'world'],
-        'b': 5
-    }
-        
-    print get_path(data, 'a')     # ['hello', 'world']
-    print get_path(data, 'a[0]')  # 'hello'
-    
-    find_path(data, '*.*')      # [['hello', 'world'], 5]
-    
-    set_path({}, 'not_there[4].more', 'value')
-    # {'not_there': [None, None, None, {'more': 'value'}]}
+print get_path(data, 'a')     # ['hello', 'world']
+print get_path(data, 'a[0]')  # 'hello'
+
+find_path(data, '*.*')      # [['hello', 'world'], 5]
+
+set_path({}, 'not_there[4].more', 'value')
+# {'not_there': [None, None, None, {'more': 'value'}]}
+```
     
 Known issues
 ------------

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ Examples:
 
 | JSONPath | `datapath` equivalents |
 | -------- | -----------------------|
-| $.a | a, .a, ["a"], ['a']
-| $.[7] | [7]
-| $.* | *, .* |
-| $..a | ..a | 
-| @..a | ..a |
-| @.a | a, .a, ["a"], ['a']
+| $.a      | a, .a, ["a"], ['a']    |
+| $.[7]    | [7]                    |
+| $.*      | *, .*                  |
+| $..a     | ..a                    |
+| @..a     | ..a                    |
+| @.a      | a, .a, ["a"], ['a']    |
 
 The JSONPath spec suggest `'@.'` for local anchoring and `'$.'` for root 
 anchoring. Where anchoring is not specified or relevant datapath allows the 
@@ -51,12 +51,12 @@ omission of the leading identifiers for example:
 
 | JSONPath | `datapath` compact  |
 | -------- | ------------------- |
-| $.a, | a | 
-| @.a | a |
-| $.['a'] | a |
-| @.['a'] | a |
-| $.["a"] | a |
-| @.["a"] | a |
+| $.a, | a |                     |
+| @.a | a  |                     |
+| $.['a']  | a                   |
+| @.['a']  | a                   |
+| $.["a"]  | a                   |
+| @.["a"]  | a                   |
 
 **NOTE!** - Currently `datapath` doesn't allow anchoring markers
 
@@ -107,4 +107,4 @@ Known issues
  * This library doesn't work, and using it is a fools errand
  * Attempting to set recursive paths (e.g. 'a..b') doesn't work
  * Recursive paths in general are likely to have undefined behavior
-   
+  


### PR DESCRIPTION
- use triple-backtick code-blocks, with python syntax highlighting (looks pretty on github)
- fix table alignment
